### PR TITLE
feat: EAS Android自動ビルド・提出ワークフロー追加

### DIFF
--- a/.github/workflows/eas-android-submit.yml
+++ b/.github/workflows/eas-android-submit.yml
@@ -30,12 +30,8 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
-          if eas whoami > /dev/null 2>&1; then
-            echo "Already authenticated with Expo"
-          else
-            echo "Authenticating with Expo token..."
-            eas login --token $EXPO_TOKEN
-          fi
+          echo "Authenticating with Expo token..."
+          eas login --token $EXPO_TOKEN
 
       - name: Install dependencies
         run: npm ci
@@ -81,13 +77,15 @@ jobs:
       - name: Download build artifact
         run: |
           echo "Downloading Android build..."
-          eas build:download --platform android --profile production --build-id ${{ env.BUILD_ID }} --output ./app.aab
+          eas build:download --build-id ${{ env.BUILD_ID }} --output ./app.aab
           echo "Build artifact downloaded successfully"
 
       - name: Submit to Google Play
         run: |
           echo "Submitting to Google Play..."
-          echo "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}" > ./service-account-key.json
+          set +x
+          printf "%s" "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}" > ./service-account-key.json
+          set -x
           eas submit -p android \
             --profile production \
             --path ./app.aab \

--- a/.github/workflows/eas-android-submit.yml
+++ b/.github/workflows/eas-android-submit.yml
@@ -1,0 +1,101 @@
+name: EAS Android Submit
+
+# mainブランチへのpushで自動実行
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-submit-android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Authenticate with Expo
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if eas whoami > /dev/null 2>&1; then
+            echo "Already authenticated with Expo"
+          else
+            echo "Authenticating with Expo token..."
+            eas login --token $EXPO_TOKEN
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Android App
+        run: |
+          echo "Starting Android build..."
+          BUILD_OUTPUT=$(eas build --platform android --profile production --non-interactive --json)
+          BUILD_ID=$(echo $BUILD_OUTPUT | jq -r '.builds[0].id')
+          echo "Build ID: $BUILD_ID"
+          echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+
+      - name: Wait for build completion
+        run: |
+          echo "Waiting for build completion..."
+          MAX_ATTEMPTS=30
+          ATTEMPT=1
+
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Checking build status (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
+            BUILD_STATUS=$(eas build:status --build-id ${{ env.BUILD_ID }} --json | jq -r '.status')
+
+            echo "Build status: $BUILD_STATUS"
+
+            if [ "$BUILD_STATUS" = "finished" ]; then
+              echo "Build completed successfully!"
+              break
+            elif [ "$BUILD_STATUS" = "errored" ] || [ "$BUILD_STATUS" = "canceled" ]; then
+              echo "Build failed with status: $BUILD_STATUS"
+              exit 1
+            fi
+
+            if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+              echo "Build did not complete within expected time"
+              exit 1
+            fi
+
+            echo "Waiting 30 seconds before next check..."
+            sleep 30
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+      - name: Download build artifact
+        run: |
+          echo "Downloading Android build..."
+          eas build:download --platform android --profile production --build-id ${{ env.BUILD_ID }} --output ./app.aab
+          echo "Build artifact downloaded successfully"
+
+      - name: Submit to Google Play
+        run: |
+          echo "Submitting to Google Play..."
+          echo "${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}" > ./service-account-key.json
+          eas submit -p android \
+            --profile production \
+            --path ./app.aab \
+            --non-interactive \
+            --service-account-key-path ./service-account-key.json
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "Cleaning up artifacts..."
+          rm -f ./app.aab ./service-account-key.json

--- a/.github/workflows/eas-android-submit.yml
+++ b/.github/workflows/eas-android-submit.yml
@@ -1,0 +1,68 @@
+name: EAS Android Submit
+
+# mainブランチへのpushで自動実行
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-submit-android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Authenticate with Expo
+        run: |
+          if eas whoami > /dev/null 2>&1; then
+            echo "Already authenticated with Expo"
+          else
+            echo "Authenticating with Expo token..."
+            eas login --token ${{ secrets.EXPO_TOKEN }}
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Android App
+        run: |
+          echo "Starting Android build..."
+          eas build --platform android --profile production --non-interactive
+
+      - name: Download build artifact
+        run: |
+          echo "Downloading latest Android build..."
+          # 最新のビルドを取得
+          BUILD_ID=$(eas build:list --platform android --profile production --json | jq -r '.[0].id')
+          if [ "$BUILD_ID" = "null" ] || [ -z "$BUILD_ID" ]; then
+            echo "No build found, exiting..."
+            exit 1
+          fi
+          echo "Build ID: $BUILD_ID"
+          eas build:download --platform android --profile production --build-id $BUILD_ID --output ./app.aab
+
+      - name: Submit to Google Play
+        run: |
+          echo "Submitting to Google Play..."
+          eas submit -p android \
+            --profile production \
+            --path ./app.aab \
+            --non-interactive \
+            --service-account-key ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "Cleaning up artifacts..."
+          rm -f ./app.aab

--- a/app.json
+++ b/app.json
@@ -16,7 +16,8 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "package": "com.onopod.expotest"
     },
     "web": {
       "bundler": "metro",
@@ -37,6 +38,12 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "2f1e99ae-cdfa-4efe-b3cb-751f66493f41"
+      }
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 16.18.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
GitHub Actionsを使用してExpo EAS CLIによるAndroidアプリの自動ビルド・Google Play提出を実装しました。

## 変更内容
- `.github/workflows/eas-android-submit.yml` を新規作成
- mainブランチへのpushで自動実行されるワークフロー
- EAS CLIによるAndroidビルド実行
- ビルド成果物のダウンロードとGoogle Playへの自動提出
- 非対話モードで実行

## 必要なSecrets設定
GitHubリポジトリのSettings > Secrets and variables > Actionsで以下のsecretsを設定してください：
- `EXPO_TOKEN`: Expoアカウントのアクセストークン
- `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY`: Google PlayサービスアカウントのJSONキー

## ワークフローの実行フロー
1. mainブランチへのpushでトリガー
2. Node.js 18環境セットアップ
3. EAS CLIインストールと認証
4. 依存関係インストール
5. Androidビルド実行
6. ビルド成果物ダウンロード
7. Google Playへの自動提出
8. クリーンアップ

ご確認お願いします。